### PR TITLE
properly indicate involved working groups for a subset of projects

### DIFF
--- a/Documents/DC2_Plan/main.tex
+++ b/Documents/DC2_Plan/main.tex
@@ -270,7 +270,6 @@ Brief summaries of how the analysis and technical working groups plan to use the
 \item [{[C]}] Similar to the above, but considering selection based on colors/magnitudes, such as extreme emission line galaxy selection.
 \item [{[C,I]}] Testing LSS analysis pipeline (including angular power spectrum estimation with mode projection for systematics) for selected galaxy subsamples.
 \item[{[I]}] Measuring magnification bias in the presence of realistic systematics.
-\item[{[I]}] Testing the impact of a selected set of theoretical and observational systematics on two-point clustering measurements.
 \end{enumerate}
 \item Photometric redshifts (PZ):
 \begin{enumerate}
@@ -294,16 +293,26 @@ Brief summaries of how the analysis and technical working groups plan to use the
 \item Weak lensing (WL):
 \begin{enumerate}
 \item[{[I]}] Validating weak lensing shear two-point correlation measurements in the presence of realistic image-level systematics and survey masks.
-\item[{[C,I]}] Testing the full end-to-end weak lensing cosmology inference pipeline, from images to cosmological parameters, including marginalization over both observational and theoretical systematics.
 \item[{[I]}] Investigating the impact of realistic levels of blending on weak lensing galaxy samples selection and shear biases.
 \item[{[I]}] Testing the effectiveness of PSF modeling routines, and the impact of residual systematics on weak lensing.
-\item[{[C]}] Testing the hierarchical Bayesian mass reconstruction from tomographic weak lensing and galaxy clustering in LSST.
-\item[{[C]}] Evaluating the impact of the ability to model over small-scale theoretical uncertainties (nonlinear bias, assembly bias, etc.) in the 3x2pt analysis, and push to smaller scales in the analysis.
 \end{enumerate}
 \item Sensor Anomalies (SA):
 \begin{enumerate}
 \item[{[C,I]}] Validate the simulation and the  correction of the Brighter-Fatter (BF)  effect .
 \item[{[I]}]  Evaluate the acceptable level of  BF residual in key analysis . 
+\end{enumerate}
+\item Cross working group projects:
+\begin{enumerate}
+\item[{[I]}] Testing the impact of a selected set of theoretical and observational systematics on
+  two-point clustering measurements (LSS, TJP).
+\item[{[C,I]}] Testing the full end-to-end weak lensing cosmology inference pipeline, from images to
+  cosmological parameters, including marginalization over both observational and theoretical
+  systematics (WL, TJP).
+\item[{[C]}] Testing the hierarchical Bayesian mass reconstruction from tomographic weak lensing and
+  galaxy clustering in LSST (WL, TJP).
+\item[{[C]}] Evaluating the impact of the ability to model over small-scale theoretical
+  uncertainties (nonlinear bias, assembly bias, etc.) in the 3x2pt analysis, and push to smaller
+  scales in the analysis (WL, LSS, TJP).
 \end{enumerate}
 \end{itemize}
 


### PR DESCRIPTION
This very small PR involves mild changes in section 3 of the DC2 planning document to properly indicate that some of the planned DC2 analyses listed as science drivers will have heavy involvement by more than one working group.  The relevant collaborations are (WL, TJP) and (LSS, TJP) and (WL, LSS, TJP) as indicated in the document.  This addresses the issue that TJP did not appear to be represented previously (whereas really it was implicitly there in some of the projects).

Flagging this to TJP conveners, @jablazek @elikrause @philbull 