### PR TITLE
Add example of running validateDrp.py on Run1.1-test2 repo.

### DIFF
--- a/scripts/run_validate_drp.sh
+++ b/scripts/run_validate_drp.sh
@@ -1,0 +1,8 @@
+# 2018-05-01: Wood-Vasey 
+#   Running the validate_drp.py LSST SRD analysis is very straightforward.
+#   Just run the below against the repository of interest.
+#
+#   However, this is not memory efficient.
+#   This takes several hours just to run on the 66 visits of Run1.1-test2
+REPO=/global/projecta/projectdirs/lsst/global/in2p3/Run1.1-test2/output
+validateDrp.py ${REPO}


### PR DESCRIPTION
Simple example of how to run the `validate_drp` framework that calculates LSST SRDs.

Check out the outputs on NERSC in

`/global/projecta/projectdirs/lsst/global/in2p3/Run1.1-test2/summary/validate_drp`

The summary report: `report_performance.rst`
Image files are all of the `*.png` files.

Take a look at https://dmtn-008.lsst.io/ for a brief refresher.

Takes 3 hours and peaks at 80 GB of memory usage.  We (I) will need to improve the performance of `validate_drp` for full DC2 (or even just Run 1.2).