### PR TITLE
match truth catalog to extragalactic catalog

### DIFF
--- a/Notebooks/FoFCatalogMatching Histogram.ipynb
+++ b/Notebooks/FoFCatalogMatching Histogram.ipynb
@@ -5,8 +5,8 @@
    "metadata": {},
    "source": [
     "# Match truth and coadd catalogs for DC2 Run 1.1p\n",
-    "Owner: Yao-Yuan Mao, Anže Slosar, Bhairav Valera;  \n",
-    "Last Verified to Run: 2018-07-19\n",
+    "Owner: Yao-Yuan Mao, Scott Daniel (with help from Anže Slosar, Bhairav Valera, HyeYun Park) <br>\n",
+    "Last Verified to Run: 2018-07-23\n",
     "\n",
     "**Notes:**\n",
     "- Follow this [step-by-step guide](https://confluence.slac.stanford.edu/x/Xgg4Dg) if you don't know how to run this notebook.\n",
@@ -18,7 +18,8 @@
     "  2. Use `filters` and `native_filters` appropriately\n",
     "  3. Use `add_quantity_modifier` and `get_quantity_modifier`\n",
     "  4. Use `FoFCatalogMatching` to do Friends-of-friends catalog matching\n",
-    "  5. Learn some cool Numpy tricks for binning, masking, and reshaping [Advanced]"
+    "  5. Learn some cool Numpy tricks for binning, masking, and reshaping [Advanced]\n",
+    "  6. Learn use pandas to match truth catalog object id back to the galaxy id in extragalactic catalog [advanced]"
    ]
   },
   {
@@ -67,8 +68,8 @@
     "# For coadd catalogs, the different chunks happen to be different patches, \n",
     "# resulting in a different color for each patch in the scatter plot below.\n",
     "\n",
-    "for coadd_coord in coadd_cat.get_quantities(['ra', 'dec'], return_iterator=True):\n",
-    "    plt.scatter(coadd_coord['ra'], coadd_coord['dec'], s=1, rasterized=True);\n",
+    "for coadd_data in coadd_cat.get_quantities(['ra', 'dec'], return_iterator=True):\n",
+    "    plt.scatter(coadd_data['ra'], coadd_data['dec'], s=1, rasterized=True);\n",
     "\n",
     "plt.xlabel('RA');\n",
     "plt.ylabel('Dec');"
@@ -113,8 +114,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Load ra and dec from coadd, using both of the filters we just defined\n",
-    "coadd_coord = coadd_cat.get_quantities(['ra', 'dec'], filters=(coord_filters + mag_filters))"
+    "# let's add total ellipticity for later use (not needed for now)\n",
+    "coadd_cat.add_derived_quantity('shape_hsm_regauss_etot', np.hypot, 'ext_shapeHSM_HsmShapeRegauss_e1', 'ext_shapeHSM_HsmShapeRegauss_e2')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load ra and dec from coadd, using both of the filters we just defined. (why not also grab e1 and e2 for later use?)\n",
+    "coadd_data = coadd_cat.get_quantities(['ra', 'dec', 'mag_i', 'shape_hsm_regauss_etot'], filters=(coord_filters + mag_filters))"
    ]
   },
   {
@@ -173,7 +184,7 @@
     "# get ra and dec from truth catalog\n",
     "# note that we add i < 24.5 to the native filter to speed up load time\n",
     "truth_native_filters = (coord_filters + ['i < 24.5'])\n",
-    "truth_coord = truth_cat.get_quantities(['ra','dec','object_id','star','sprinkled'], filters=mag_filters, native_filters=truth_native_filters)\n",
+    "truth_data = truth_cat.get_quantities(['ra', 'dec', 'object_id', 'star', 'sprinkled'], filters=mag_filters, native_filters=truth_native_filters)\n",
     "\n",
     "# We will use the object_id, star, and sprinkled columns when cross-referencing truth information with the extragalactic catalog."
    ]
@@ -191,7 +202,7 @@
     "# so we need to specify `catalog_len_getter` so that the code knows how to get the length of the catalog.\n",
     "\n",
     "results = FoFCatalogMatching.match(\n",
-    "    catalog_dict={'truth': truth_coord, 'coadd': coadd_coord},\n",
+    "    catalog_dict={'truth': truth_data, 'coadd': coadd_data},\n",
     "    linking_lengths=1.0,\n",
     "    catalog_len_getter=lambda x: len(x['ra']),\n",
     ")"
@@ -258,8 +269,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "truth_sc = SkyCoord(truth_coord['ra'][truth_idx], truth_coord['dec'][truth_idx], unit=\"deg\")\n",
-    "coadd_sc = SkyCoord(coadd_coord['ra'][coadd_idx], coadd_coord['dec'][coadd_idx], unit=\"deg\")\n",
+    "truth_sc = SkyCoord(truth_data['ra'][truth_idx], truth_data['dec'][truth_idx], unit=\"deg\")\n",
+    "coadd_sc = SkyCoord(coadd_data['ra'][coadd_idx], coadd_data['dec'][coadd_idx], unit=\"deg\")\n",
     "\n",
     "delta_ra = (coadd_sc.ra.arcsec - truth_sc.ra.arcsec) * np.cos(np.deg2rad(0.5*(truth_sc.dec.deg + coadd_sc.dec.deg)))\n",
     "delta_dec = coadd_sc.dec.arcsec - truth_sc.dec.arcsec\n",
@@ -298,32 +309,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Most of the astrophysical truth information about the objects in DC2 is actually stored in the extragalactic catalog.  The truth catalog only contains the positions and magnitudes that we believe should have been produced by the image simulators.  To access further truth information (redshift, shape parameters, mass), we must cross-reference the truth catalog with the extragalactic catalog.  This can be done via the column `object_id` in the truth catalog, which maps directly to `galaxy_id` in the extragalactic catalog."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# First, load the extragalactic catalog that was used for this simulation\n",
-    "extragalactic_cat = GCRCatalogs.load_catalog('proto-dc2_v2.1.2')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# load redshift and shear parameters from the extragalactic catalog\n",
-    "extragalactic_qties = extragalactic_cat.get_quantities(['galaxy_id', 'redshift', 'shear_1', 'shear_2', 'magnification'])\n",
+    "### Going one step further\n",
     "\n",
-    "# make sure the extragalactic quantities are sorted by galaxy_id so that we can use np.searchsorted to match to the truth quantities\n",
-    "sorted_dex = np.argsort(extragalactic_qties['galaxy_id'])\n",
-    "for name in extragalactic_qties:\n",
-    "    extragalactic_qties[name] = extragalactic_qties[name][sorted_dex]"
+    "Most of the astrophysical truth information about the objects in DC2 is actually stored in the extragalactic catalog.  The truth catalog only contains the positions and magnitudes that we believe should have been produced by the image simulators.  To access further truth information (redshift, shape parameters, mass), we must cross-reference the truth catalog with the extragalactic catalog.  This can be done via the column `object_id` in the truth catalog, which maps directly to `galaxy_id` in the extragalactic catalog.\n",
+    "\n",
+    "Let's use pandas for this part to make our lives a bit easier :) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# convert truth_data and coadd_data to pandas dataframe and select the matched one\n",
+    "truth_matched = pd.DataFrame(truth_data).iloc[truth_idx].reset_index(drop=True)\n",
+    "coadd_matched = pd.DataFrame(coadd_data).iloc[coadd_idx].reset_index(drop=True)\n",
+    "matched = pd.merge(truth_matched, coadd_matched, left_index=True, right_index=True, suffixes=('_truth', '_coadd'))"
    ]
   },
   {
@@ -334,10 +345,7 @@
    "source": [
     "# Select only those truth objects that are galaxies which were not sprinkled\n",
     "# (stars and sprinkled objects do not occur in the extragalactic catalog)\n",
-    "valid_truth = np.where(np.logical_and(truth_coord['star'][truth_idx]==0,\n",
-    "                                      truth_coord['sprinkled'][truth_idx]==0))\n",
-    "\n",
-    "truth_gal_idx = truth_idx[valid_truth]"
+    "matched_gals = matched.query('~star').query('~sprinkled')"
    ]
   },
   {
@@ -346,11 +354,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# use np.searchsorted to associate truth catalog objects with extragalactic_catalog objects\n",
-    "extragalactic_truth_idx = np.searchsorted(extragalactic_qties['galaxy_id'],\n",
-    "                                           truth_coord['object_id'][truth_gal_idx])\n",
-    "\n",
-    "# extra_galactic_truth_idx will now give the indices of objects in extragalactic_qties that map to truth_coord objects"
+    "# First, load the extragalactic catalog that was used for this simulation (using _test to skip md5 check)\n",
+    "extragalactic_cat = GCRCatalogs.load_catalog('proto-dc2_v2.1.2_test')"
    ]
   },
   {
@@ -359,9 +364,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(len(extragalactic_truth_idx))\n",
-    "print(len(truth_coord['object_id'][truth_gal_idx]))\n",
-    "print(extragalactic_qties['galaxy_id'])"
+    "# load redshift and shear parameters from the extragalactic catalog, only for galaxise that are already in `matched_gals`\n",
+    "extragalactic_data = extragalactic_cat.get_quantities(\n",
+    "    ['galaxy_id', 'mag_i', 'ellipticity_true', 'shear_1', 'shear_2'],\n",
+    "    filters=[(lambda x: np.in1d(x, matched_gals['object_id'].values, True), 'galaxy_id')]\n",
+    ")"
    ]
   },
   {
@@ -370,8 +377,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.testing.assert_array_equal(extragalactic_qties['galaxy_id'][extragalactic_truth_idx],\n",
-    "                              truth_coord['object_id'][truth_gal_idx])"
+    "# merge extragalactic_data to matched_gals\n",
+    "matched_gals = pd.merge(matched_gals, pd.DataFrame(extragalactic_data), 'left', left_on='object_id', right_on='galaxy_id', suffixes=('', '_extra'))"
    ]
   },
   {
@@ -380,10 +387,59 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# What is the redshift distribution of objects that were matched 1-to-1?\n",
-    "plt.hist(extragalactic_qties['redshift'][extragalactic_truth_idx], bins=100);\n",
-    "plt.xlabel('redshift')"
+    "np.testing.assert_array_equal(matched_gals['object_id'], matched_gals['galaxy_id'])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# check out the table \n",
+    "matched_gals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# compare the magnitude\n",
+    "plt.figure(figsize=(5,5));\n",
+    "plt.scatter(matched_gals['mag_i'], matched_gals['mag_i_extra'], s=1);\n",
+    "lims = [14, 26]\n",
+    "plt.plot(lims, lims, c='k', lw=0.5);\n",
+    "plt.xlabel('$i$ coadd');\n",
+    "plt.ylabel('$i$ extragalactic');\n",
+    "plt.xlim(lims);\n",
+    "plt.ylim(lims);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# compare the ellipticity\n",
+    "plt.figure(figsize=(5,5));\n",
+    "plt.scatter(matched_gals['shape_hsm_regauss_etot'], matched_gals['ellipticity_true'], s=1);\n",
+    "lims = [0, 1]\n",
+    "plt.plot(lims, lims, c='k', lw=0.5);\n",
+    "plt.xlabel('ellipticity coadd');\n",
+    "plt.ylabel('ellipticity extragalactic');\n",
+    "plt.xlim(lims);\n",
+    "plt.ylim(lims);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/Notebooks/FoFCatalogMatching Histogram.ipynb
+++ b/Notebooks/FoFCatalogMatching Histogram.ipynb
@@ -172,7 +172,10 @@
    "source": [
     "# get ra and dec from truth catalog\n",
     "# note that we add i < 24.5 to the native filter to speed up load time\n",
-    "truth_coord = truth_cat.get_quantities(['ra','dec'], filters=mag_filters, native_filters=(coord_filters + ['i < 24.5']))"
+    "truth_native_filters = (coord_filters + ['i < 24.5'])\n",
+    "truth_coord = truth_cat.get_quantities(['ra','dec','object_id','star','sprinkled'], filters=mag_filters, native_filters=truth_native_filters)\n",
+    "\n",
+    "# We will use the object_id, star, and sprinkled columns when cross-referencing truth information with the extragalactic catalog."
    ]
   },
   {
@@ -292,11 +295,95 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Most of the astrophysical truth information about the objects in DC2 is actually stored in the extragalactic catalog.  The truth catalog only contains the positions and magnitudes that we believe should have been produced by the image simulators.  To access further truth information (redshift, shape parameters, mass), we must cross-reference the truth catalog with the extragalactic catalog.  This can be done via the column `object_id` in the truth catalog, which maps directly to `galaxy_id` in the extragalactic catalog."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# First, load the extragalactic catalog that was used for this simulation\n",
+    "extragalactic_cat = GCRCatalogs.load_catalog('proto-dc2_v2.1.2')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load redshift and shear parameters from the extragalactic catalog\n",
+    "extragalactic_qties = extragalactic_cat.get_quantities(['galaxy_id', 'redshift', 'shear_1', 'shear_2', 'magnification'])\n",
+    "\n",
+    "# make sure the extragalactic quantities are sorted by galaxy_id so that we can use np.searchsorted to match to the truth quantities\n",
+    "sorted_dex = np.argsort(extragalactic_qties['galaxy_id'])\n",
+    "for name in extragalactic_qties:\n",
+    "    extragalactic_qties[name] = extragalactic_qties[name][sorted_dex]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Select only those truth objects that are galaxies which were not sprinkled\n",
+    "# (stars and sprinkled objects do not occur in the extragalactic catalog)\n",
+    "valid_truth = np.where(np.logical_and(truth_coord['star'][truth_idx]==0,\n",
+    "                                      truth_coord['sprinkled'][truth_idx]==0))\n",
+    "\n",
+    "truth_gal_idx = truth_idx[valid_truth]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# use np.searchsorted to associate truth catalog objects with extragalactic_catalog objects\n",
+    "extragalactic_truth_idx = np.searchsorted(extragalactic_qties['galaxy_id'],\n",
+    "                                           truth_coord['object_id'][truth_gal_idx])\n",
+    "\n",
+    "# extra_galactic_truth_idx will now give the indices of objects in extragalactic_qties that map to truth_coord objects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(len(extragalactic_truth_idx))\n",
+    "print(len(truth_coord['object_id'][truth_gal_idx]))\n",
+    "print(extragalactic_qties['galaxy_id'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.testing.assert_array_equal(extragalactic_qties['galaxy_id'][extragalactic_truth_idx],\n",
+    "                              truth_coord['object_id'][truth_gal_idx])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What is the redshift distribution of objects that were matched 1-to-1?\n",
+    "plt.hist(extragalactic_qties['redshift'][extragalactic_truth_idx], bins=100);\n",
+    "plt.xlabel('redshift')"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR adds cells to the FoF matching notebook that show how to cross-reference the truth catalog with the extra-galactic catalog.